### PR TITLE
Fix icons proptypes import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,127 @@
+{
+  "name": "par-ui",
+  "version": "0.0.90",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "requires": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.9"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "^3.0.0"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+      "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "ua-parser-js": {
+      "version": "0.7.18",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+      "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+    },
+    "whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "par-ui",
-  "version": "0.0.90",
+  "version": "0.0.91",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "babel-polyfill": "^6.23.0",
     "moment": "^2.18.1",
+    "prop-types": "^15.6.1",
     "react": "^15.4.2",
     "react-currency-input": "^1.2.6",
     "react-dom": "^15.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "par-ui",
-  "version": "0.0.90",
+  "version": "0.0.91",
   "description": "Parmais React Components Library",
   "directories": {
     "doc": "docs",

--- a/src/icons/arrowchart.js
+++ b/src/icons/arrowchart.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Arrowchart extends Component {
   render() {
@@ -25,7 +26,7 @@ class Arrowchart extends Component {
   }
 }
 
-Arrowchart.propTypes = {
+Arrowchart.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/attach.js
+++ b/src/icons/attach.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Attach extends Component {
   render() {
@@ -23,7 +24,7 @@ class Attach extends Component {
   }
 }
 
-Attach.propTypes = {
+Attach.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/attention.js
+++ b/src/icons/attention.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Attention extends Component {
   render() {
@@ -18,7 +19,7 @@ class Attention extends Component {
   }
 }
 
-Attention.propTypes = {
+Attention.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/calendar.js
+++ b/src/icons/calendar.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Calendar extends Component {
   render() {
@@ -41,7 +42,7 @@ class Calendar extends Component {
   }
 }
 
-Calendar.propTypes = {
+Calendar.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/check.js
+++ b/src/icons/check.js
@@ -1,6 +1,5 @@
-import React, {Component, PropTypes} from 'react';
-
-
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Check extends Component {
   render() {
@@ -27,7 +26,7 @@ class Check extends Component {
   }
 }
 
-Check.propTypes = {
+Check.PropTypes = {
   size: PropTypes.number,
   height: PropTypes.number,
   width: PropTypes.number,

--- a/src/icons/clock.js
+++ b/src/icons/clock.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Clock extends Component {
 
@@ -46,7 +47,7 @@ class Clock extends Component {
   }
 }
 
-Clock.propTypes = {
+Clock.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/columnchart.js
+++ b/src/icons/columnchart.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Columnchart extends Component {
   render() {
@@ -28,7 +29,7 @@ class Columnchart extends Component {
   }
 }
 
-Columnchart.propTypes = {
+Columnchart.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/contract.js
+++ b/src/icons/contract.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Contract extends Component {
   render() {
@@ -24,7 +25,7 @@ class Contract extends Component {
   }
 }
 
-Contract.propTypes = {
+Contract.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/download.js
+++ b/src/icons/download.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Download extends Component {
   render() {
@@ -24,7 +25,7 @@ class Download extends Component {
   }
 }
 
-Download.propTypes = {
+Download.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/expand.js
+++ b/src/icons/expand.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Expand extends Component {
   render() {
@@ -24,7 +25,7 @@ class Expand extends Component {
   }
 }
 
-Expand.propTypes = {
+Expand.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/flag.js
+++ b/src/icons/flag.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Flag extends Component {
   render() {
@@ -14,7 +15,7 @@ class Flag extends Component {
   }
 }
 
-Flag.propTypes = {
+Flag.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/hammer.js
+++ b/src/icons/hammer.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Hammer extends Component {
   render() {
@@ -26,7 +27,7 @@ class Hammer extends Component {
   }
 }
 
-Hammer.propTypes = {
+Hammer.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/happy.js
+++ b/src/icons/happy.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Happy extends Component {
   render() {
@@ -25,7 +26,7 @@ class Happy extends Component {
   }
 }
 
-Happy.propTypes = {
+Happy.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/lessBG.js
+++ b/src/icons/lessBG.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class LessBG extends Component {
   render() {
@@ -14,7 +15,7 @@ class LessBG extends Component {
   }
 }
 
-LessBG.propTypes = {
+LessBG.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/linechart.js
+++ b/src/icons/linechart.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Linechart extends Component {
   render() {
@@ -22,7 +23,7 @@ class Linechart extends Component {
   }
 }
 
-Linechart.propTypes = {
+Linechart.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/lock.js
+++ b/src/icons/lock.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Lock extends Component {
   render() {
@@ -20,7 +21,7 @@ class Lock extends Component {
   }
 }
 
-Lock.propTypes = {
+Lock.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/magnifier.js
+++ b/src/icons/magnifier.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Magnifier extends Component {
   render() {
@@ -22,7 +23,7 @@ class Magnifier extends Component {
   }
 }
 
-Magnifier.propTypes = {
+Magnifier.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/navdown.js
+++ b/src/icons/navdown.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Navright extends Component {
   render() {
@@ -25,7 +26,7 @@ class Navright extends Component {
   }
 }
 
-Navright.propTypes = {
+Navright.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/navleft.js
+++ b/src/icons/navleft.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Navleft extends Component {
   render() {
@@ -25,7 +26,7 @@ class Navleft extends Component {
   }
 }
 
-Navleft.propTypes = {
+Navleft.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/navright.js
+++ b/src/icons/navright.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Navdown extends Component {
   render() {
@@ -25,7 +26,7 @@ class Navdown extends Component {
   }
 }
 
-Navdown.propTypes = {
+Navdown.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/navup.js
+++ b/src/icons/navup.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Navup extends Component {
   render() {
@@ -25,7 +26,7 @@ class Navup extends Component {
   }
 }
 
-Navup.propTypes = {
+Navup.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/next.js
+++ b/src/icons/next.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Next extends Component {
   render() {
@@ -25,7 +26,7 @@ class Next extends Component {
   }
 }
 
-Next.propTypes = {
+Next.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/oops.js
+++ b/src/icons/oops.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Oops extends Component {
   render() {
@@ -27,7 +28,7 @@ class Oops extends Component {
   }
 }
 
-Oops.propTypes = {
+Oops.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/paper.js
+++ b/src/icons/paper.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Paper extends Component {
   render() {
@@ -24,7 +25,7 @@ class Paper extends Component {
   }
 }
 
-Paper.propTypes = {
+Paper.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/pig.js
+++ b/src/icons/pig.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Pig extends Component {
   render() {
@@ -20,7 +21,7 @@ class Pig extends Component {
   }
 }
 
-Pig.propTypes = {
+Pig.PropTypes = {
   height: PropTypes.number,
   width: PropTypes.number,
   size: PropTypes.number,

--- a/src/icons/plugBG.js
+++ b/src/icons/plugBG.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class PlusBG extends Component {
   render() {
@@ -14,7 +15,7 @@ class PlusBG extends Component {
   }
 }
 
-PlusBG.propTypes = {
+PlusBG.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/plus.js
+++ b/src/icons/plus.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Plus extends Component {
   render() {
@@ -25,7 +26,7 @@ class Plus extends Component {
   }
 }
 
-Plus.propTypes = {
+Plus.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/profile.js
+++ b/src/icons/profile.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Profile extends Component {
   render() {
@@ -17,7 +18,7 @@ class Profile extends Component {
   }
 }
 
-Profile.propTypes = {
+Profile.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/rocket.js
+++ b/src/icons/rocket.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Rocket extends Component {
   render() {
@@ -17,7 +18,7 @@ class Rocket extends Component {
   }
 }
 
-Rocket.propTypes = {
+Rocket.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/sad.js
+++ b/src/icons/sad.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Sad extends Component {
   render() {
@@ -25,7 +26,7 @@ class Sad extends Component {
   }
 }
 
-Sad.propTypes = {
+Sad.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/trash.js
+++ b/src/icons/trash.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Trash extends Component {
   render() {
@@ -25,7 +26,7 @@ class Trash extends Component {
   }
 }
 
-Trash.propTypes = {
+Trash.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/wallet.js
+++ b/src/icons/wallet.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Wallet extends Component {
   render() {
@@ -37,7 +38,7 @@ class Wallet extends Component {
   }
 }
 
-Wallet.propTypes = {
+Wallet.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,

--- a/src/icons/x.js
+++ b/src/icons/x.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class X extends Component {
   render() {
@@ -25,7 +26,7 @@ class X extends Component {
   }
 }
 
-X.propTypes = {
+X.PropTypes = {
   size: PropTypes.number,
   color: PropTypes.string,
   background: PropTypes.string,


### PR DESCRIPTION
The PropTypes library is now separated of React lib. This PR fix this problem in icons component and prevents errors and alerts from occurring in the browser console.